### PR TITLE
V110 issue004

### DIFF
--- a/report.py
+++ b/report.py
@@ -20,11 +20,11 @@ from tghours import hours
 # -----------------------------------------------------
 
 
-def update_events():
+def update_events(report_date, window_days=None):
     '''Update events database sqlite and gsheet with new NowThen records
     '''
     hours.load()
-    hours.update_events()
+    hours.update_events(report_date, window_days)
 
 def update_activity_report():
     pass
@@ -45,7 +45,15 @@ def autorun():
     if len(sys.argv) > 1:
         process_name = sys.argv[1]
         if process_name == 'update_events':
-            update_events()
+            if len(sys.argv) > 2:
+                report_date = sys.argv[2]
+                if len(sys.argv) > 3:
+                    window_days = int(sys.argv[3])
+                    update_events(report_date, window_days)
+                else:
+                    update_events(report_date)
+            else:
+                update_events(None)
         elif process_name == 'update_activity_report':
             update_activity_report()
     else:

--- a/tghours/hours.py
+++ b/tghours/hours.py
@@ -130,22 +130,22 @@ def events_std_format(data, filename='', report_date=None, window_days=None):
     ''' create events from Toggl data table
     '''
     events = []
-    #try:
-    #01 convert the dates and create activity label
-    if not report_date:
-        report_date = dt.datetime.today().strftime(toggl.TOGGL_DATE_FORMAT)
-    if window_days:
-        std = toggl.std_events_from_api(report_date, window_days=window_days)
-    else:
-        std = toggl.std_events_from_api(report_date)
-    # std = toggl.standard_form(data)  # deprecated
-    # std = nt_standardForm(data)      # deprecated, NowThen method
+    try:
+        #01 convert the dates and create activity label
+        if not report_date:
+            report_date = dt.datetime.today().strftime(toggl.TOGGL_DATE_FORMAT)
+        if window_days:
+            std = toggl.std_events_from_api(report_date, window_days=window_days)
+        else:
+            std = toggl.std_events_from_api(report_date)
+        # std = toggl.standard_form(data)  # deprecated
+        # std = nt_standardForm(data)      # deprecated, NowThen method
 
-    if len(std) > 0:
-        #02 add year, month, week
-        events = TimeSeriesTable(std, dtField='timestamp').ts
+        if len(std) > 0:
+            #02 add year, month, week
+            events = TimeSeriesTable(std, dtField='timestamp').ts
 
-    #except:
-    #    pass
+    except:
+        pass
 
     return events

--- a/tghours/hours.py
+++ b/tghours/hours.py
@@ -57,13 +57,13 @@ def gs_load():
 #-----------------------------------------------------
 
 
-def update_events(report_date=None):
+def update_events(report_date=None, window_days=None):
     '''Update events database sqlite and gsheet with new Toggl records
     '''
     global events
 
     #01 load new events
-    new_events = events_std_format(None, '', report_date)
+    new_events = events_std_format(None, '', report_date=report_date, window_days=window_days)
     has_new_events = len(new_events) > 0
 
     #02 load db events
@@ -126,23 +126,26 @@ def load_events():
     return has_events
 
 
-def events_std_format(data, filename='', report_date=None):
+def events_std_format(data, filename='', report_date=None, window_days=None):
     ''' create events from Toggl data table
     '''
     events = []
-    try:
-        #01 convert the dates and create activity label
-        if not report_date:
-            report_date = dt.datetime.today().strftime(toggl.TOGGL_DATE_FORMAT)
+    #try:
+    #01 convert the dates and create activity label
+    if not report_date:
+        report_date = dt.datetime.today().strftime(toggl.TOGGL_DATE_FORMAT)
+    if window_days:
+        std = toggl.std_events_from_api(report_date, window_days=window_days)
+    else:
         std = toggl.std_events_from_api(report_date)
-        # std = toggl.standard_form(data)  # deprecated
-        # std = nt_standardForm(data)      # deprecated, NowThen method
+    # std = toggl.standard_form(data)  # deprecated
+    # std = nt_standardForm(data)      # deprecated, NowThen method
 
-        if len(std) > 0:
-            #02 add year, month, week
-            events = TimeSeriesTable(std, dtField='timestamp').ts
+    if len(std) > 0:
+        #02 add year, month, week
+        events = TimeSeriesTable(std, dtField='timestamp').ts
 
-    except:
-        pass
+    #except:
+    #    pass
 
     return events


### PR DESCRIPTION
see #4
three changes in this update
1. toggl API bug --> when fetching projects use the user projects instead of workspace projects
2. toggl API bug --> toggl uses 2x time formats, one with Z = Zulu, and other +00:00 which mean the same thing. standardize and any instance of 'Z' substitute with '+00:00'
3. add argument to cli for window days for manual repair  to update past x days