### PR TITLE
migrate to remote and add sync procedure

### DIFF
--- a/report.py
+++ b/report.py
@@ -24,7 +24,12 @@ def update_events(report_date, window_days=None):
     '''Update events database sqlite and gsheet with new NowThen records
     '''
     hours.load()
-    hours.update_events(report_date, window_days)
+    hours.report_update(report_date, window_days)
+
+
+def sync():
+    hours.db_sync()
+
 
 def update_activity_report():
     pass
@@ -56,8 +61,11 @@ def autorun():
                 update_events(None)
         elif process_name == 'update_activity_report':
             update_activity_report()
+        elif process_name == 'sync':
+            sync()
     else:
         print('no report specified')
+
 
 if __name__ == "__main__":
     autorun()

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ greenlet==1.1.2
 setuptools~=59.6.0
 zipp==3.6.0
 wheel>=0.38.1
-sqlite-gsheet>=1.3
+sqlite-gsheet>=1.4.0

--- a/tghours/hours.py
+++ b/tghours/hours.py
@@ -7,6 +7,7 @@ import json
 import pandas as pd
 import datetime as dt
 from sqlgsheet import database as db
+from sqlgsheet.sync import update as sync_update
 from tghours.time_series import TimeSeriesTable
 from tghours import toggl
 #-----------------------------------------------------
@@ -15,7 +16,13 @@ from tghours import toggl
 
 
 #constants
+SYNC_FILE = 'dbsync_config.json'
+DATE_FORMAT = '%Y-%m-%d'
 GS_WKB_NAME = 'hours'
+GS_CLIENT_SECRET_FILE = 'client_secret.json'
+DB_EVENT_TABLE = 'tgevents'
+LAST_MODIFIED_FIELD = 'last_modified'
+KEY_FIELD = 'timestamp'
 WINDOW_YEARS = 1
 HRS_IN_WEEK = 168
 HRS_IN_DAY = 24
@@ -39,15 +46,16 @@ def load():
 
 
 def db_load():
-    db.DB_SOURCE = 'local'
-    db.SQL_DB_NAME = 'sqlite:///hours.db'
+    db.DB_SOURCE = 'remote'
+    #db.SQL_DB_NAME = 'sqlite:///hours.db'
     db.load_sql()
 
 
 def gs_load():
-    with open('client_secret.json') as f:
+    with open(GS_CLIENT_SECRET_FILE) as f:
         client_secret = json.loads(f.read())
     f.close()
+    db.gs.CLIENT_SECRET_FILE = GS_CLIENT_SECRET_FILE
     db.load_client_secret(client_secret)
     db.GSHEET_CONFIG = json.load(open('gsheet_config.json'))
 
@@ -57,69 +65,9 @@ def gs_load():
 #-----------------------------------------------------
 
 
-def update_events(report_date=None, window_days=None):
-    '''Update events database sqlite and gsheet with new Toggl records
-    '''
-    global events
-
-    #01 load new events
-    new_events = events_std_format(None, '', report_date=report_date, window_days=window_days)
-    has_new_events = len(new_events) > 0
-
-    #02 load db events
-    has_events = load_events()
-
-    if has_new_events:
-        if has_events:
-            events = events.append(new_events)
-        else:
-            events = new_events.copy()
-            has_events = True
-
-        # 04 drop duplicates and sort
-        events = events[~events.index.duplicated(keep='first')]
-        events.sort_index(inplace=True)
-
-        # 05 push updates to sqlite
-        db.update_table(events.reset_index()[EVENT_FIELDS],
-                        'event',
-                        False)
-        db.unload_sql()
-
-    if has_events:
-        # 06 format fields for gsheet
-        rngcode = 'events'
-
-        # 06.01 date and time to str
-        date_format = db.GSHEET_CONFIG[GS_WKB_NAME]['sheets'][rngcode]['date_format']
-        time_format = db.GSHEET_CONFIG[GS_WKB_NAME]['sheets'][rngcode]['time_format']
-
-        def event_time_convert(time_value):
-            time_str = ''
-            if isinstance(time_value, str):
-                time_str = time_value[:-3]
-            else:
-                time_str = time_value.strftime(time_format)
-            return time_str
-
-        events['date'] = events['date'].apply(lambda x: dt.datetime.strftime(x, date_format))
-        events['time'] = events['time'].apply(lambda x: event_time_convert(x))
-
-        # 06.02 fill empty str for blank comment fields
-        events['comment'].fillna('', inplace=True)
-
-        #07 push recent events to gsheet
-        min_year = events['year'].max() - WINDOW_YEARS + 1
-        recent = events[events['year'] >= min_year].copy()
-        db.load_gsheet()
-        db.post_to_gsheet(recent[
-            [f for f in EVENT_FIELDS if not f == 'timestamp']], GS_WKB_NAME, rngcode, 'USER_ENTERED')
-        db.gs_engine = None
-
-
 def load_events():
     global events
-    events = db.get_table('event')
+    events = db.get_table(DB_EVENT_TABLE)
     has_events = not events is None
     if has_events:
         events.set_index('timestamp', inplace=True)
@@ -138,14 +86,115 @@ def events_std_format(data, filename='', report_date=None, window_days=None):
             std = toggl.std_events_from_api(report_date, window_days=window_days)
         else:
             std = toggl.std_events_from_api(report_date)
-        # std = toggl.standard_form(data)  # deprecated
-        # std = nt_standardForm(data)      # deprecated, NowThen method
 
         if len(std) > 0:
             #02 add year, month, week
-            events = TimeSeriesTable(std, dtField='timestamp').ts
+            events = TimeSeriesTable(std, dtField=KEY_FIELD).ts
 
     except:
         pass
 
     return events
+
+
+def report_update(report_date=None, window_days=None):
+    """ updates the database with new events from api and updates google sheet report
+    """
+    api_rows = events_std_format(None, '', report_date=report_date, window_days=window_days)
+    if len(api_rows) > 0:
+        api_rows.reset_index(inplace=True)
+        db_update(api_rows)
+    report_post()
+
+
+def db_update(api_rows: pd.DataFrame, has_duplicates=True):
+    """ updates the database with new events from api
+    """
+    if db.table_exists(DB_EVENT_TABLE) and has_duplicates:
+        unique_rows = remove_duplicates(api_rows)
+        if len(unique_rows) > 0:
+            db_update(unique_rows, has_duplicates=False)
+    else:
+        db_rows_insert(api_rows)
+
+
+def remove_duplicates(api_rows: pd.DataFrame) -> pd.DataFrame:
+    """ removes duplicates and returns only unique events from api that are not in the db
+    """
+    # get the events from the db
+    db_events = db_query()
+
+    # add only the new events not already in the database
+    not_in_db = pd.concat([db_events, db_events, api_rows])
+    not_in_db.drop_duplicates(
+        subset=[KEY_FIELD],
+        keep=False,
+        inplace=True
+    )
+
+    return not_in_db
+
+
+def db_query() -> pd.DataFrame:
+    db_events = db.get_table(DB_EVENT_TABLE)
+    if db_events is None:
+        db_events = pd.DataFrame([])
+    else:
+        if LAST_MODIFIED_FIELD in db_events:
+            del db_events[LAST_MODIFIED_FIELD]
+    return db_events
+
+
+def db_rows_insert(rows: pd.DataFrame):
+    with_lm = add_lm_timestamp(rows)
+    if db.table_exists(DB_EVENT_TABLE):
+        db.rows_insert(with_lm, DB_EVENT_TABLE, con=db.con)
+    else:
+        db.update_table(with_lm, DB_EVENT_TABLE, append=False)
+
+
+def add_lm_timestamp(rows: pd.DataFrame) -> pd.DataFrame:
+    with_lm = rows.copy()
+    if len(with_lm) > 0:
+        last_modified = dt.datetime.now()
+        with_lm[LAST_MODIFIED_FIELD] = last_modified
+    return with_lm
+
+
+def report_post():
+    """ query events from db and publish to the google sheets report
+    """
+    # 06 format fields for gsheet
+    rngcode = 'events'
+
+    # 06.01 date and time to str
+    gs_date_format = db.GSHEET_CONFIG[GS_WKB_NAME]['sheets'][rngcode]['date_format']
+    time_format = db.GSHEET_CONFIG[GS_WKB_NAME]['sheets'][rngcode]['time_format']
+
+    def event_time_convert(time_value):
+        time_str = ''
+        if isinstance(time_value, str):
+            time_str = time_value[:-3]
+        else:
+            time_str = time_value.strftime(time_format)
+        return time_str
+
+    db_events = db_query()
+    db_events['date'] = db_events['date'].apply(lambda x: dt.datetime.strptime(x, DATE_FORMAT))
+    db_events['date'] = db_events['date'].apply(lambda x: dt.datetime.strftime(x, gs_date_format))
+    db_events['time'] = db_events['time'].apply(lambda x: event_time_convert(x))
+
+    # 06.02 fill empty str for blank comment fields
+    db_events['comment'].fillna('', inplace=True)
+
+    # 07 push recent events to gsheet
+    min_year = db_events['year'].max() - WINDOW_YEARS + 1
+    recent = db_events[db_events['year'] >= min_year].copy()
+    db.load_gsheet()
+    db.post_to_gsheet(recent[[f for f in EVENT_FIELDS if not f == 'timestamp']],
+                      GS_WKB_NAME, rngcode, 'USER_ENTERED')
+    db.gs_engine = None
+
+
+def db_sync():
+    sync_update(config_path=SYNC_FILE)

--- a/tghours/time_series.py
+++ b/tghours/time_series.py
@@ -18,39 +18,46 @@ import math
 # TimeSeriesTable
 # -----------------------------------------------------
 
-class TimeSeriesTable():
+class TimeSeriesTable(object):
     data = None
     ts = None
     dtField = ''
-    def __init__(self,data,dtField='datetime'):
+
+    def __init__(self, data, dtField='datetime'):
         if isinstance(data,pd.DataFrame):
             self.data = data
             self.dtField = dtField
-            if self.is_timeSeries(data)>0:
+            if self.is_timeSeries(data) > 0:
                 self.ts = self.as_timeSeries(data)
-    def is_timeSeries(self,data):
+
+    def is_timeSeries(self, data):
         cond = [0 for x in range(3)]
-        cond[0] = len(data)>0
+        cond[0] = len(data) > 0
         cond[1] = self.dtField in data.columns
+
         if (cond[0] and cond[1]):
             cond[2] = isinstance(data.iloc[0][self.dtField],dt.datetime)
         return all(cond)
+
     def as_timeSeries(self,data):
         ts = data.copy()
         ts = self.addFields_ymwk(ts)
-        ts.set_index(self.dtField,inplace=True)
+        ts.set_index(self.dtField, inplace=True)
         return ts
+
     def addFields_ymwk(self,data):
-        data['year'] = data.apply(lambda x:x[self.dtField].year,axis=1)
-        data['month'] = data.apply(lambda x:x[self.dtField].month,axis=1)
+        data['year'] = data.apply(lambda x:x[self.dtField].year, axis=1)
+        data['month'] = data.apply(lambda x:x[self.dtField].month, axis=1)
         data['week'] = data.apply(lambda x:self.get_weekNumber(x[self.dtField]),axis=1)
-        data['DOW'] = data.apply(lambda x:x[self.dtField].weekday(),axis=1)
+        data['DOW'] = data.apply(lambda x:x[self.dtField].weekday(), axis=1)
         return data
-    def get_weekNumber(self,dateValue):
+
+    def get_weekNumber(self, dateValue):
         yearLng = dateValue.year
-        yearStartDate = dt.datetime(yearLng,1,1) - dt.timedelta(dt.datetime(yearLng,1,1).weekday())
+        yearStartDate = dt.datetime(yearLng, 1, 1) - dt.timedelta(dt.datetime(yearLng, 1, 1).weekday())
         weekNumber = math.floor((dateValue-yearStartDate).days/7)+1
         return weekNumber
+
     def head(self):
         return self.ts.head()
 


### PR DESCRIPTION
## events update with last modified and backup sync

### 01 events update based on new events row insert
The current update method is based on table replace and has been buggy with several instances of complete data loss.  The new updated method is based on row insert, so only the new rows are appended to the table.

![update_with_lm_diagram](https://github.com/taylorhickem/tg-hours/assets/35887093/fb34beee-6fad-4e3b-b1ee-b1232f17cb7e)

### 02 db sync
for details refer to [sqlgsheet new feature: db sync](https://github.com/taylorhickem/sqlite-gsheet/issues/26)

Integrating new db-sync feature from the [sqlite-gsheet package 1.4.0](https://github.com/taylorhickem/sqlite-gsheet/).  In the new workflow new updates are applied to remote (slave) mySQL database , and in a seperate procedure the remote database is periodically synced once a week with a local master database.  The timing of the syncs are such that in the event of data compromise to the slave DB during the routine updates, the master is not immediately impacted and there is time to respond and repair manual changes to both databases before the next sync. Then once the repairs are complete the routine updates and the syncs can resume.  